### PR TITLE
Nested minishell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = minishell
-SRC = minishell.c get_cmd_path.c simple_helpers.c command_execution.c execution_utils.c ft_split_custom.c builtins.c parser_utils.c expand_dollar_v2.c pipe.c pipe_utils.c pipe_utils2.c pipe_append.c env_export.c local_getenv.c free_utils.c memory.c counting_utils.c unset_env.c
+SRC = minishell.c get_cmd_path.c simple_helpers.c command_execution.c execution_utils.c ft_split_custom.c builtins.c parser_utils.c expand_dollar_v2.c pipe.c pipe_utils.c pipe_utils2.c pipe_append.c env_export.c local_getenv.c free_utils.c memory.c counting_utils.c unset_env.c expand_dollar_utils.c
 OBJ = $(SRC:.c=.o)
 DEP = $(SRC:.c=.d)
 LINK_LIBFT = -Llibft -lft

--- a/builtins.c
+++ b/builtins.c
@@ -6,13 +6,13 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/02 12:12:03 by aalsuwai          #+#    #+#             */
-/*   Updated: 2022/03/23 17:15:42 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 12:51:53 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	env(t_parser_info *p)
+int	env(t_parser_info *p)//change to accept uppercase like ENV, EnV, Env
 {
 	int	i;
 
@@ -22,7 +22,7 @@ int	env(t_parser_info *p)
 	return(0);
 }
 
-int	pwd(t_parser_info *p)
+int	pwd(t_parser_info *p) //change to accept uppercase
 {
 	char	cwd[PATH_MAX];
 	if (!getcwd(cwd, sizeof(cwd)))
@@ -36,7 +36,7 @@ int	pwd(t_parser_info *p)
 	return (0);
 }
 
-int	echo(t_parser_info *p, char **argv)
+int	echo(t_parser_info *p, char **argv)//change to accept uppercase AND to accept -nnnn -n -n
 {
 	int		i;
 	bool	newline_flag;
@@ -134,19 +134,6 @@ int	cd(t_parser_info *p, char **argv)
 	return(0);
 }
 
-
-int	ft_str_isdigit(char *str)
-{
-	int	i;
-
-	i = 0;
-	while (str[i] >= '0' && str[i] <= '9')
-		i++;
-	if (str[i] == '\0')
-		return (1);
-	return (0);
-}
-
 void	baby_exit(t_parser_info *p, char **cmd)
 {
 	//catch cases of failure
@@ -158,7 +145,6 @@ void	baby_exit(t_parser_info *p, char **cmd)
 	exit_flag = true;
 	if (!p->pipes_count)
 		printf("exit\n");
-
 	if (!cmd[1])
 		p->exit_code = (unsigned char)p->exit_code;
 	else

--- a/builtins.c
+++ b/builtins.c
@@ -6,13 +6,13 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/02 12:12:03 by aalsuwai          #+#    #+#             */
-/*   Updated: 2022/03/29 12:51:53 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 14:20:37 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	env(t_parser_info *p)//change to accept uppercase like ENV, EnV, Env
+int	env(t_parser_info *p)
 {
 	int	i;
 
@@ -22,7 +22,7 @@ int	env(t_parser_info *p)//change to accept uppercase like ENV, EnV, Env
 	return(0);
 }
 
-int	pwd(t_parser_info *p) //change to accept uppercase
+int	pwd(t_parser_info *p)
 {
 	char	cwd[PATH_MAX];
 	if (!getcwd(cwd, sizeof(cwd)))
@@ -36,7 +36,7 @@ int	pwd(t_parser_info *p) //change to accept uppercase
 	return (0);
 }
 
-int	echo(t_parser_info *p, char **argv)//change to accept uppercase AND to accept -nnnn -n -n
+int	echo(t_parser_info *p, char **argv)//change to accept -nnnn -n -n
 {
 	int		i;
 	bool	newline_flag;
@@ -58,23 +58,71 @@ int	echo(t_parser_info *p, char **argv)//change to accept uppercase AND to accep
 	return (0);
 }
 
+// int	echo(t_parser_info *p, char **argv)//change to accept uppercase AND to accept -nnnn -n -n
+// {
+// 	int		i;
+// 	bool	found_word;
+// 	bool	newline_flag;
+
+// 	i = 1;
+// 	newline_flag = true;
+// 	found_word = false;
+// 	while (argv[i])
+// 	{
+// 		if (!found_word && !ft_strncmp(argv[1], "-n", 2))
+// 		{
+// 			while ()
+// 			newline_flag = false;
+// 			i++;
+// 		}
+// 		else
+// 		{
+// 			printf("%s", argv[i++]);
+// 			if (argv[i + 1])
+// 				printf(" ");
+// 			found_word = true;
+// 			i++;
+// 		}
+// 	}
+// 	if (newline_flag)
+// 		printf("\n");
+// 	p->exit_code = 0;
+// 	return (0);
+// }
+
 int	export(t_parser_info *p, char **cmd)
 {
-	int	i;
+	int		i;
+	bool	failed;
 	
 	i = 1;
+	failed = false;
 	while (cmd[i])
+	{
 		p->env = export_env(p, p->env, cmd[i++]);
+		if (p->exit_code == 1)
+			failed = true;	
+	}
+	if (failed)
+		p->exit_code = 1;
 	return (0);
 }
 
 int	unset(t_parser_info *p, char **cmd)
 {
-	int	i;
+	int		i;
+	bool	failed;
 	
 	i = 1;
+	failed = false;
 	while (cmd[i])
+	{
 		p->env = unset_env(p, p->env, cmd[i++]);
+		if (p->exit_code == 1)
+			failed = true;
+	}
+	if (failed)
+		p->exit_code = 1;
 	return (0);
 }
 
@@ -98,7 +146,7 @@ int	cd(t_parser_info *p, char **argv)
 		}
 		else if (!opendir(temp) || chdir(temp) == -1)
 		{
-			temp = ft_strjoin("minishell: cd: ", argv[1]);
+			temp = ft_strjoin("minishell: cd: ", temp);
 			perror(temp);
 			free(temp);
 			p->exit_code = 1;
@@ -109,7 +157,7 @@ int	cd(t_parser_info *p, char **argv)
 		if (!opendir(argv[1]) || chdir(argv[1]) == -1)
 		{
 			temp = ft_strjoin("minishell: cd: ", argv[1]);
-			perror(ft_strjoin("minishell: cd: ", argv[1]));
+			perror(temp);
 			free(temp);
 			p->exit_code = 1;
 		}
@@ -149,9 +197,9 @@ void	baby_exit(t_parser_info *p, char **cmd)
 		p->exit_code = (unsigned char)p->exit_code;
 	else
 	{
-		if (ft_str_isdigit(cmd[1]) == 1 && !cmd[2])
+		if (ft_str_isdigit(cmd[1]) == 1 && !cmd[2] && !check_longmax(cmd[1]))
 			p->exit_code = (unsigned char)ft_atoi(cmd[1]);
-		else if (ft_str_isdigit(cmd[1]) == 1 && cmd[2])
+		else if (ft_str_isdigit(cmd[1]) == 1 && cmd[2] && !check_longmax(cmd[1]))
 		{
 			p->exit_code = 1;
 			exit_flag = false;
@@ -173,6 +221,7 @@ void	baby_exit(t_parser_info *p, char **cmd)
 	//if cmd[0] is higer than longmax it should fail
 	//also other cases should be accounted for where exit fails
 	//too many cases!!!
+	//exit 9223372036854775807 .. -9223372036854775808
 }
 /*
 Exit cases:

--- a/builtins.c
+++ b/builtins.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/02 12:12:03 by aalsuwai          #+#    #+#             */
-/*   Updated: 2022/03/29 14:20:37 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 17:29:33 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,18 +36,37 @@ int	pwd(t_parser_info *p)
 	return (0);
 }
 
-int	echo(t_parser_info *p, char **argv)//change to accept -nnnn -n -n
+int	echo_index(char **argv)
+{
+	int	index;
+	int	array_index;
+
+	array_index = 1;
+	while (argv[array_index])
+	{
+		if (argv[array_index][0] != '-')
+			return (array_index);
+		index = 1;
+		while (argv[array_index][index])
+		{
+			if (argv[array_index][index] != 'n')
+				return (array_index);
+			index++;
+		}
+		array_index++;
+	}
+	return (array_index);
+}
+
+int	echo(t_parser_info *p, char **argv)
 {
 	int		i;
 	bool	newline_flag;
 
+	i = echo_index(argv);
 	newline_flag = true;
-	i = 1;
-	if (argv[1] && !ft_strncmp(argv[1], "-n", 3))
-	{
+	if (i > 1)
 		newline_flag = false;
-		i = 2;
-	}
 	if (argv[i])
 		printf("%s", argv[i++]);
 	while (argv[i] && printf(" "))
@@ -57,38 +76,6 @@ int	echo(t_parser_info *p, char **argv)//change to accept -nnnn -n -n
 	p->exit_code = 0;
 	return (0);
 }
-
-// int	echo(t_parser_info *p, char **argv)//change to accept uppercase AND to accept -nnnn -n -n
-// {
-// 	int		i;
-// 	bool	found_word;
-// 	bool	newline_flag;
-
-// 	i = 1;
-// 	newline_flag = true;
-// 	found_word = false;
-// 	while (argv[i])
-// 	{
-// 		if (!found_word && !ft_strncmp(argv[1], "-n", 2))
-// 		{
-// 			while ()
-// 			newline_flag = false;
-// 			i++;
-// 		}
-// 		else
-// 		{
-// 			printf("%s", argv[i++]);
-// 			if (argv[i + 1])
-// 				printf(" ");
-// 			found_word = true;
-// 			i++;
-// 		}
-// 	}
-// 	if (newline_flag)
-// 		printf("\n");
-// 	p->exit_code = 0;
-// 	return (0);
-// }
 
 int	export(t_parser_info *p, char **cmd)
 {

--- a/command_execution.c
+++ b/command_execution.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   command_execution.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: Alia <Alia@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/18 18:48:43 by aalsuwai          #+#    #+#             */
-/*   Updated: 2022/03/27 17:41:10 by Alia             ###   ########.fr       */
+/*   Updated: 2022/03/28 14:48:01 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ static void	single_child_process(t_parser_info *p, int pipe_append[2])
 		exit(p->exit_code);
 	}
 	if (p->cmd_path[0])
-		execve(p->cmd_path[0], p->cmd[0], 0);
+		execve(p->cmd_path[0], p->cmd[0], p->env);
 	if (p->in_fd > 1)
 		close(p->in_fd);
 // 	else if (p->in_fd == 1) // i don't think i need it cuz i close both ends after duping
@@ -119,7 +119,11 @@ void	execute_single_command(t_parser_info *p)
 	}
 	else
 	{
+		if (ft_strrchr(p->cmd[0][0], '/') && !ft_strncmp(ft_strrchr(p->cmd[0][0], '/') + 1, "minishell", 10))
+			signal(SIGINT, SIG_IGN);
 		waitpid(p->child_pids[0], &status, 0);
+		if (ft_strrchr(p->cmd[0][0], '/') && !ft_strncmp(ft_strrchr(p->cmd[0][0], '/') + 1, "minishell", 10))
+			signal(SIGINT, handle_signals);
 		p->exit_code = WEXITSTATUS(status); //check the logic of getting the exit code
 		if (p->cmd[0][0] && !builtin_check(p, 0))
 			builtin_execute(p, 0);

--- a/command_execution.c
+++ b/command_execution.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/18 18:48:43 by aalsuwai          #+#    #+#             */
-/*   Updated: 2022/03/28 14:48:01 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 12:49:03 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,17 +44,17 @@ static void	single_child_process(t_parser_info *p, int pipe_append[2])
 
 int	builtin_execute(t_parser_info *p, int i)
 {
-	if (!ft_strncmp(p->cmd[i][0], "echo", 5))
+	if (!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "echo", 5))
 		return (echo(p, p->cmd[i]));
 	else if (!ft_strncmp(p->cmd[i][0], "cd", 3))
 		return (cd(p, p->cmd[i]));
-	else if (!ft_strncmp(p->cmd[i][0], "pwd", 4))
+	else if (!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "pwd", 4))
 		return (pwd(p));
 	else if (!ft_strncmp(p->cmd[i][0], "export", 7))
 		return (export(p, p->cmd[i]));
 	else if (!ft_strncmp(p->cmd[i][0], "unset", 6))
 		return (unset(p, p->cmd[i]));
-	else if (!ft_strncmp(p->cmd[i][0], "env", 4))
+	else if (!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "env", 4))
 		return (env(p));
 	else if (!ft_strncmp(p->cmd[i][0], "clear", 6))
 		return (clear());
@@ -74,9 +74,9 @@ int	builtin_check(t_parser_info *p, int i)
 	!ft_strncmp(p->cmd[i][0], "clear", 6) || \
 	!ft_strncmp(p->cmd[i][0], "exit", 5))
 		return (0);
-	else if (!ft_strncmp(p->cmd[i][0], "echo", 5) || \
-	!ft_strncmp(p->cmd[i][0], "pwd", 4) || \
-	!ft_strncmp(p->cmd[i][0], "env", 4))
+	else if (!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "echo", 5) || \
+	!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "pwd", 4) || \
+	!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "env", 4))
 		return (1);
 	return (2);
 }

--- a/command_execution.c
+++ b/command_execution.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/18 18:48:43 by aalsuwai          #+#    #+#             */
-/*   Updated: 2022/03/29 12:49:03 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 15:07:46 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,8 +56,8 @@ int	builtin_execute(t_parser_info *p, int i)
 		return (unset(p, p->cmd[i]));
 	else if (!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "env", 4))
 		return (env(p));
-	else if (!ft_strncmp(p->cmd[i][0], "clear", 6))
-		return (clear());
+	else if (!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "clear", 6))
+		return (clear(p));
 	else if (!ft_strncmp(p->cmd[i][0], "exit", 5))
 	{
 		baby_exit(p, p->cmd[i]);
@@ -71,7 +71,7 @@ int	builtin_check(t_parser_info *p, int i)
 	if (!ft_strncmp(p->cmd[i][0], "cd", 3) || \
 	!ft_strncmp(p->cmd[i][0], "export", 7) || \
 	!ft_strncmp(p->cmd[i][0], "unset", 6) || \
-	!ft_strncmp(p->cmd[i][0], "clear", 6) || \
+	!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "clear", 6) || \
 	!ft_strncmp(p->cmd[i][0], "exit", 5))
 		return (0);
 	else if (!ft_strncmp(ft_str_tolower(p->cmd[i][0]), "echo", 5) || \

--- a/expand_dollar_utils.c
+++ b/expand_dollar_utils.c
@@ -1,0 +1,47 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_dollar_utils.c                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/03/29 11:49:56 by anasr             #+#    #+#             */
+/*   Updated: 2022/03/29 12:30:07 by anasr            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	len_dollar_question(int *i, int *len, t_parser_info *p)
+{
+	char	*temp;
+	
+	temp = ft_itoa(p->exit_code);
+	(*len) += ft_strlen(temp);
+	(*i) += 2;
+	free(temp);
+}
+
+void	expand_dollar_question(int *i, int *new_index, char *expanded, t_parser_info *p)
+{
+	char	*temp;
+
+	temp = ft_itoa(p->exit_code);
+	ft_strcpy(&expanded[*new_index], temp);
+	(*new_index) += ft_strlen(temp);
+	free(temp);
+	(*i) += 2;
+}
+
+void	len_dollar_general(int *i, int *len, char *str, t_parser_info *p)
+{
+	(*len) += ft_strlen(ft_getenv((*i), str, p));
+	skip_dollar_content(i, str);
+}
+
+void	expand_dollar_general(int *i, int *new_index, char *str, char *expanded, t_parser_info *p)
+{
+	ft_strcpy(&expanded[*new_index], ft_getenv((*i), str, p));
+	(*new_index) = ft_strlen(ft_getenv((*i), str, p));
+	skip_dollar_content(i, str);
+}

--- a/expand_dollar_v2.c
+++ b/expand_dollar_v2.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand_dollar_v2.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aalsuwai <aalsuwai@student.42.fr>          +#+  +:+       +#+        */
+/*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/10 15:22:39 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/27 13:10:57 by aalsuwai         ###   ########.fr       */
+/*   Updated: 2022/03/29 12:36:19 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ static void	init_meta(char	**meta)
 	meta[13] = 0;
 }
 
-static char	*ft_getenv(int i, char *str, t_parser_info *p)
+char	*ft_getenv(int i, char *str, t_parser_info *p)
 {
 	int		j;
 	char	*meta[14];//"=" is added bec echo "$USER=" is anasr= or echo "$=" is $=
@@ -58,12 +58,12 @@ void	skip_dollar_content(int *i, char *str)
 	// 	(*i)++;
 }
 
-int		len_with_expansion(char	*str, t_parser_info *p) //keeping the quotes because i deal with them later
+int		len_with_expansion(char	*str, t_parser_info *p, bool append_flag) //keeping the quotes because i deal with them later
 {
-	int	i;
-	int	len;
+	int		i;
+	int		len;
 	char	*meta[14];
-	char	*temp;
+	// char	*temp;
 
 	init_meta(meta);
 	i = 0;
@@ -71,35 +71,75 @@ int		len_with_expansion(char	*str, t_parser_info *p) //keeping the quotes becaus
 	while (str[i])
 	{
 		if (str[i] == '$' && str[i + 1] == '?')
-		{
-			temp = ft_itoa(p->exit_code);
-			len += ft_strlen(temp);
-			i += 2;
-			free(temp);
-		}
+			len_dollar_question(&i, &len, p);
+		// {
+		// 	temp = ft_itoa(p->exit_code);
+		// 	len += ft_strlen(temp);
+		// 	i += 2;
+		// 	free(temp);
+		// }
 		else if (str[i] == '$' && ft_isspace(str[i + 1]) == 0 && ft_ismeta(&str[i + 1], meta) == 0 && str[i + 1])
-		{
-			// printf("dollar expanded: %s\n", ft_getenv(i, str) ? ft_getenv(i, str) : "");
-			len += ft_strlen(ft_getenv(i, str, p));
-			skip_dollar_content(&i, str);
-			// printf("length of $: %d\n", len);
-		}
+			len_dollar_general(&i, &len, str, p);
+		// {
+		// 	// printf("dollar expanded: %s\n", ft_getenv(i, str) ? ft_getenv(i, str) : "");
+		// 	len += ft_strlen(ft_getenv(i, str, p));
+		// 	skip_dollar_content(&i, str);
+		// 	// printf("length of $: %d\n", len);
+		// }
 		else if (ft_isquote(str[i]) == 1)
-			len += skip_quote_content(&i, str);
+		{
+			if (append_flag == true)//check this new addition
+			{
+				len++;
+				i++;
+				while (ft_isquote(str[i]) != 1 && str[i])
+				{
+					if (str[i] == '$' && str[i + 1] == '?')
+						len_dollar_question(&i, &len, p);
+					// {
+					// 	temp = ft_itoa(p->exit_code);
+					// 	len += ft_strlen(temp);
+					// 	i += 2;
+					// 	free(temp);
+					// }
+					else if (str[i] == '$' && ft_isspace(str[i + 1]) == 0 && ft_ismeta(&str[i + 1], meta) == 0 && str[i + 1])
+						len_dollar_general(&i, &len, str, p);
+					// {
+					// 	len += ft_strlen(ft_getenv(i, str, p));
+					// 	skip_dollar_content(&i, str);
+					// }
+					else
+					{
+						len++;
+						i++;
+					}
+				}
+			}
+			else
+				len += skip_quote_content(&i, str);
+		}
 		else if (ft_isquote(str[i]) == 2)
 		{
 			len++;
 			i++;
 			while (ft_isquote(str[i]) != 2 && str[i])
 			{
-				// printf("currently: %s\n", str + i);
-				if (str[i] == '$' && ft_isspace(str[i + 1]) == 0 && ft_ismeta(&str[i + 1], meta) == 0 && str[i + 1])
-				{
-					// printf("dollar expanded: %s\n", ft_getenv(i, str) ? ft_getenv(i, str) : "");
-					len += ft_strlen(ft_getenv(i, str, p));
-					skip_dollar_content(&i, str);
-					// printf("length of $: %d\n", len);
-				}
+				if (str[i] == '$' && str[i + 1] == '?')
+					len_dollar_question(&i, &len, p);
+				// {
+				// 	temp = ft_itoa(p->exit_code);
+				// 	len += ft_strlen(temp);
+				// 	i += 2;
+				// 	free(temp);
+				// }
+				else if (str[i] == '$' && ft_isspace(str[i + 1]) == 0 && ft_ismeta(&str[i + 1], meta) == 0 && str[i + 1])
+					len_dollar_general(&i, &len, str, p);
+				// {
+				// 	// printf("dollar expanded: %s\n", ft_getenv(i, str) ? ft_getenv(i, str) : "");
+				// 	len += ft_strlen(ft_getenv(i, str, p));
+				// 	skip_dollar_content(&i, str);
+				// 	// printf("length of $: %d\n", len);
+				// }
 				else
 				{
 					len++;
@@ -123,58 +163,91 @@ char	*expand_dollars_in_str(char *str, t_parser_info *p, bool append_flag)
 	int		new_index;
 	char	*expanded;
 	char	*meta[14];
-	char	*temp;
+	// char	*temp;
 
 	// printf("LEN: %d\n", len_with_expansion(str));
 	init_meta(meta);
-	expanded = ft_calloc(len_with_expansion(str, p) + 1, sizeof(char));
+	expanded = ft_calloc(len_with_expansion(str, p, append_flag) + 1, sizeof(char));
 	i = 0;
 	new_index = 0;
 	while (str[i])
 	{
-		// printf("currently: %s\n", str + i);
-		
 		if (str[i] == '$' && str[i + 1] == '?')
-		{
-			temp = ft_itoa(p->exit_code);
-			ft_strcpy(&expanded[new_index], temp);
-			free(temp);
-			i += 2;
-		}
+			expand_dollar_question(&i, &new_index, expanded, p);
+		// {
+		// 	temp = ft_itoa(p->exit_code);
+		// 	ft_strcpy(&expanded[new_index], temp);
+		// 	new_index += ft_strlen(temp);
+		// 	free(temp);
+		// 	i += 2;
+		// }
 		else if (str[i] == '$' && ft_isspace(str[i + 1]) == 0 && ft_ismeta(&str[i + 1], meta) == 0 && str[i + 1]) //last condition is for "echo $= "
 		{
-			// printf("dollar expanded: %s\n", ft_getenv(i, str) ? ft_getenv(i, str) : "");
 			ft_strcpy(&expanded[new_index], ft_getenv(i, str, p));
 			new_index += ft_strlen(ft_getenv(i, str, p));
 			skip_dollar_content(&i, str);
-			// printf("length of $: %d\n", len);
 		}
-		else if (ft_isquote(str[i]) == 1 && append_flag != true)
+		else if (ft_isquote(str[i]) == 1)
 		{
 			expanded[new_index++] = str[i++];
 			// printf("expanded: %s\n", expanded);
-			while (ft_isquote(str[i]) != 1 && str[i])
+			if (append_flag == true)//check this new addition
 			{
-				expanded[new_index++] = str[i];
-				i++;
+				while (ft_isquote(str[i]) != 1 && str[i])
+				{
+					if (str[i] == '$' && str[i + 1] == '?')
+						expand_dollar_question(&i, &new_index, expanded, p);
+					// {
+					// 	temp = ft_itoa(p->exit_code);
+					// 	ft_strcpy(&expanded[new_index], temp);
+					// 	new_index += ft_strlen(temp);
+					// 	free(temp);
+					// 	i += 2;
+					// }
+					else if (str[i] == '$' && ft_isspace(str[i + 1]) == 0 && ft_ismeta(&str[i + 1], meta) == 0 && str[i + 1] && ft_isquote(str[i + 1]) == 0)  //last condition is for "echo "heyey$" "
+					{
+						ft_strcpy(&expanded[new_index], ft_getenv(i, str, p));
+						new_index += ft_strlen(ft_getenv(i, str, p));
+						skip_dollar_content(&i, str);
+					}
+					else
+					{
+						expanded[new_index++] = str[i];
+						i++;
+					}
+				}
 			}
-			if (str[i])
-				expanded[new_index++] = str[i++];
+			else
+			{
+				while (ft_isquote(str[i]) != 1 && str[i])
+				{
+					expanded[new_index++] = str[i];
+					i++;
+				}
+				if (str[i])
+					expanded[new_index++] = str[i++];
+			}
 		}
-		else if (ft_isquote(str[i]) == 2 || (ft_isquote(str[i]) == 1 && append_flag == true))
+		else if (ft_isquote(str[i]) == 2)
 		{
 			expanded[new_index++] = str[i];
 			i++;
-			while ((ft_isquote(str[i]) != 2 && str[i]) || (ft_isquote(str[i]) != 1 && str[i] && append_flag == true))
+			while (ft_isquote(str[i]) != 2 && str[i])
 			{
-				// printf("currently: %s\n", str + i);
-				if (str[i] == '$' && ft_isspace(str[i + 1]) == 0 && ft_ismeta(&str[i + 1], meta) == 0 && str[i + 1] && ft_isquote(str[i + 1]) == 0)  //last condition is for "echo "heyey$" "
+				if (str[i] == '$' && str[i + 1] == '?')
+					expand_dollar_question(&i, &new_index, expanded, p);
+				// {
+				// 	temp = ft_itoa(p->exit_code);
+				// 	ft_strcpy(&expanded[new_index], temp);
+				// 	new_index += ft_strlen(temp);
+				// 	free(temp);
+				// 	i += 2;
+				// }
+				else if (str[i] == '$' && ft_isspace(str[i + 1]) == 0 && ft_ismeta(&str[i + 1], meta) == 0 && str[i + 1] && ft_isquote(str[i + 1]) == 0)  //last condition is for "echo "heyey$" "
 				{
-					// printf("dollar expanded: %s\n", ft_getenv(i, str) ? ft_getenv(i, str) : "");
 					ft_strcpy(&expanded[new_index], ft_getenv(i, str, p));
 					new_index += ft_strlen(ft_getenv(i, str, p));
 					skip_dollar_content(&i, str);
-					// printf("length of $: %d\n", len);
 				}
 				else
 				{

--- a/ft_split_custom.c
+++ b/ft_split_custom.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_split_custom.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aalsuwai <aalsuwai@student.42.fr>          +#+  +:+       +#+        */
+/*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/19 18:10:48 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/27 13:13:05 by aalsuwai         ###   ########.fr       */
+/*   Updated: 2022/03/28 15:33:54 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -185,11 +185,14 @@ static char	*get_next_word(int i, char *input, char **meta, t_parser_info *p)
 
 	len = get_next_word_len(i, input, meta);
 	temp = ft_substr(input, i, len);
-	// printf("word: %s.. len = %d\n", temp, len);
-	//where expanding the dollar occurs (commented at the moment)
-	if (ft_strchr(temp, '$'))
+
+	if (ft_strchr(temp, '$') && p->was_there_delim == false)
 		temp = expand_dollars_in_str(temp, p, false);
-	//
+
+	if (!ft_strncmp(temp, "<<", 3))
+		p->was_there_delim = true;
+	else
+		p->was_there_delim = false;
 	if (ft_strchr(temp, '\'') || ft_strchr(temp, '\"'))
 		result = strcpy_wout_quotes(temp);
 	else

--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 16:55:09 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/28 14:38:58 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 15:02:20 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,7 +86,7 @@ char	*get_cmd_path(char *cmd, t_parser_info *p)
 	while (paths_array[i])
 	{
 		temp_path = join_cmd_to_path(paths_array[i], cmd);
-		if (!access(temp_path, F_OK))
+		if (!access(temp_path, F_OK) && !access(temp_path, X_OK))
 			return (temp_path);
 		free(temp_path);
 		i++;

--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -3,14 +3,33 @@
 /*                                                        :::      ::::::::   */
 /*   get_cmd_path.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aalsuwai <aalsuwai@student.42.fr>          +#+  +:+       +#+        */
+/*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 16:55:09 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/27 16:50:09 by aalsuwai         ###   ########.fr       */
+/*   Updated: 2022/03/28 14:38:58 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+void	nested_minishell(t_parser_info *p)
+{
+	int		save;
+	char	*temp;
+	char	*shlvl;
+
+	temp = local_getenv("SHLVL", p->env);
+	if (temp)
+	{
+		save = ft_atoi(temp);
+		++save;
+		temp = ft_itoa(save);
+		shlvl = ft_strjoin("SHLVL=", temp);
+		free(temp);
+		export_env(p, p->env, shlvl);
+		free(shlvl);
+	}
+}
 
 void	change_cmd(t_parser_info *p, int array_i)
 {
@@ -26,6 +45,8 @@ void	change_cmd(t_parser_info *p, int array_i)
 	}
 	else
 	{
+		if (!ft_strncmp(ft_strrchr(p->cmd[array_i][0], '/') + 1, "minishell", 10))
+			nested_minishell(p);
 		p->cmd_path[array_i] = ft_strdup(p->cmd[array_i][0]);
 		free(p->cmd[array_i][0]);
 		p->cmd[array_i][0] = ft_strdup(ft_strrchr(p->cmd_path[array_i], '/') + 1);

--- a/minishell.c
+++ b/minishell.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 05:56:45 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/28 19:27:20 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 15:09:09 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -128,7 +128,7 @@ void	handle_signals(int signum)
 
 	p = return_p(NULL);
 	//this is not working as of yet for some unknown reason
-	if (!p->command_in_action)
+	if (p->command_in_action)
 		p->exit_code = 130;
 	else
 		p->exit_code = 1;

--- a/minishell.c
+++ b/minishell.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 05:56:45 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/29 15:09:09 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 16:51:15 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -127,11 +127,8 @@ void	handle_signals(int signum)
 	t_parser_info	*p;
 
 	p = return_p(NULL);
-	//this is not working as of yet for some unknown reason
 	if (p->command_in_action)
-		p->exit_code = 130;
-	else
-		p->exit_code = 1;
+		p->signal_in_cmd = true;
 	if (signum == SIGINT)
 	{
 		write(1, "\n", 1);

--- a/minishell.c
+++ b/minishell.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aalsuwai <aalsuwai@student.42.fr>          +#+  +:+       +#+        */
+/*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 05:56:45 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/27 12:49:17 by aalsuwai         ###   ########.fr       */
+/*   Updated: 2022/03/28 19:27:20 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -127,6 +127,11 @@ void	handle_signals(int signum)
 	t_parser_info	*p;
 
 	p = return_p(NULL);
+	//this is not working as of yet for some unknown reason
+	if (!p->command_in_action)
+		p->exit_code = 130;
+	else
+		p->exit_code = 1;
 	if (signum == SIGINT)
 	{
 		write(1, "\n", 1);
@@ -175,7 +180,7 @@ int	main(int argc, char **argv, char **env)
 		if (!input)
 		{
 			free_double_char(p.env);
-			exit(0);
+			exit(p.exit_code);
 		}
 		if (input[0])
 			add_history(input);

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/18 19:19:34 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/28 15:25:02 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 12:47:47 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,6 +115,8 @@ char	**dup_array(char **a1);
 char	*ft_strndup(const char *s1, int n);
 void	skip_isspaces(int *index, char *input);
 char	*ft_strcpy(char *dst, const char *src);
+int		ft_str_isdigit(char *str);
+char	*ft_str_tolower(char *str);
 
 /* ------------- ** command path ** ------------- */
 
@@ -130,7 +132,16 @@ char	**ft_split_custom(char *input, char **meta, t_parser_info *p);
 
 /* ------------ ** expand dollar ** ------------- */
 
+void	skip_dollar_content(int *i, char *str);
+char	*ft_getenv(int i, char *str, t_parser_info *p);
 char	*expand_dollars_in_str(char *str, t_parser_info *p, bool append_flag);
+
+/* ---------- ** expand dollar utils ** --------- */
+
+
+void	len_dollar_question(int *i, int *len, t_parser_info *p);
+void	expand_dollar_question(int *i, int *new_index, char *expanded, t_parser_info *p);
+void	len_dollar_general(int *i, int *len, char *str, t_parser_info *p);
 
 /* ----------- ** execution utils ** ------------ */
 

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/18 19:19:34 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/29 14:31:22 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 16:40:26 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,6 +93,8 @@ typedef struct s_parser_info
 	bool	in_append_inprogress;
 	bool	command_in_action;
 	bool	was_there_delim;
+
+	bool	signal_in_cmd;
 
 	int		exit_code;
 }	t_parser_info;

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/18 19:19:34 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/29 12:47:47 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 14:31:22 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -110,13 +110,14 @@ int		check_repeated_meta(char *input, t_parser_info *p);
 
 /* ------------ ** simple helpers ** ------------ */
 
-int		clear(void);
 char	**dup_array(char **a1);
+int		clear(t_parser_info *p);
 char	*ft_strndup(const char *s1, int n);
 void	skip_isspaces(int *index, char *input);
 char	*ft_strcpy(char *dst, const char *src);
 int		ft_str_isdigit(char *str);
 char	*ft_str_tolower(char *str);
+int		check_longmax(char *str);
 
 /* ------------- ** command path ** ------------- */
 

--- a/minishell.h
+++ b/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aalsuwai <aalsuwai@student.42.fr>          +#+  +:+       +#+        */
+/*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/18 19:19:34 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/27 13:11:57 by aalsuwai         ###   ########.fr       */
+/*   Updated: 2022/03/28 15:25:02 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,6 +92,7 @@ typedef struct s_parser_info
 
 	bool	in_append_inprogress;
 	bool	command_in_action;
+	bool	was_there_delim;
 
 	int		exit_code;
 }	t_parser_info;

--- a/pipe.c
+++ b/pipe.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipe.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: Alia <Alia@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/08 16:42:32 by aalsuwai          #+#    #+#             */
-/*   Updated: 2022/03/27 17:44:40 by Alia             ###   ########.fr       */
+/*   Updated: 2022/03/28 14:35:13 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ static void	pipe_child_process(t_parser_info *p, int **pip, int pip_i, int **pip
 		exit(p->exit_code);
 	}
 	if (p->cmd_path[pip_i])
-		execve(p->cmd_path[pip_i], p->cmd[pip_i], 0);
+		execve(p->cmd_path[pip_i], p->cmd[pip_i], p->env);
 	close_remaining_pipes(pipe_append, pip, pip_i, p->pipes_count);
 	free_n_close(p, pip, pipe_append);
 	exit(p->exit_code);

--- a/pipe.c
+++ b/pipe.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/08 16:42:32 by aalsuwai          #+#    #+#             */
-/*   Updated: 2022/03/28 14:35:13 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 14:26:17 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,11 +34,18 @@ static void	pipe_child_process(t_parser_info *p, int **pip, int pip_i, int **pip
 /* --------------------------------- Parent -------------------------------- */
 static void	parent_process(t_parser_info *p, int **pip, int **pipe_append)
 {
+	int	i;
 	int	status;
 
+	i = -1;
 	close_all_pipes_fds(p, pip, pipe_append);
-	while (waitpid(-1, &status, 0) > 0)
+	while (++i < p->pipes_count + 1)
+	{
+		waitpid(p->child_pids[i], &status, 0);
 		p->exit_code = WEXITSTATUS(status);
+	}
+	// while (waitpid(-1, &status, 0) > 0)
+	// 	p->exit_code = WEXITSTATUS(status);
 	free_double_int(pip, p->pipes_count);
 	free_double_int(pipe_append, (p->pipes_count + 1));
 }

--- a/simple_helpers.c
+++ b/simple_helpers.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 17:52:09 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/29 12:49:43 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 14:30:59 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,16 +38,18 @@ void	skip_isspaces(int *index, char *input)
 		(*index)++;
 }
 
-int		clear(void)
+int		clear(t_parser_info *p)
 {
 	printf("\e[1;1H\e[2J"); //this one doesn't delete history
 	// printf("\033c"); //this one deletes the history of the terminal
+	p->exit_code = 0;
 	return (0);
 }
 
 char	*ft_strcpy(char *dst, const char *src)
 {
-	int i;
+	int	i;
+
 	i = 0;
 	while (src && src[i])
 	{
@@ -60,7 +62,7 @@ char	*ft_strcpy(char *dst, const char *src)
 
 char	**dup_array(char **a1)
 {
-	int	i;
+	int		i;
 	char	**new_a;
 
 	i = 0;
@@ -77,18 +79,19 @@ char	**dup_array(char **a1)
 	return (new_a);
 }
 
-int		ft_str_isdigit(char *str)
+int	ft_str_isdigit(char *str)
 {
 	int	i;
 
 	i = 0;
+	if (str[i] == '-')
+		i++;
 	while (str[i] >= '0' && str[i] <= '9')
 		i++;
 	if (str[i] == '\0')
 		return (1);
 	return (0);
 }
-
 
 char	*ft_str_tolower(char *str)
 {
@@ -98,4 +101,33 @@ char	*ft_str_tolower(char *str)
 	while (str[++i])
 		str[i] = ft_tolower(str[i]);
 	return (str);
+}
+
+int		check_longmax(char *str)
+{
+	int			i;
+	int			sign;
+	int			count;
+	long long	result;
+
+	i = 0;
+	sign = 1;
+	count = 0;
+	result = 0;
+	if (str[i] == '-')
+	{
+		sign = -1;
+		i++;
+	}
+	while (ft_isdigit(str[i]) == 1)
+	{
+		if (result >= 9223372036854775807 / 10 && str[i] > '7' && sign == 1)
+			return (1);
+		if ((result >= 9223372036854775807 / 10 && str[i] > '8') || count > 19)
+			return (1);
+		result = 10 * result + (str[i] - 48);
+		i++;
+		count++;
+	}
+	return (0);
 }

--- a/simple_helpers.c
+++ b/simple_helpers.c
@@ -6,7 +6,7 @@
 /*   By: anasr <anasr@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/14 17:52:09 by anasr             #+#    #+#             */
-/*   Updated: 2022/03/17 14:02:23 by anasr            ###   ########.fr       */
+/*   Updated: 2022/03/29 12:49:43 by anasr            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,4 +75,27 @@ char	**dup_array(char **a1)
 	}
 	new_a[i] = 0;
 	return (new_a);
+}
+
+int		ft_str_isdigit(char *str)
+{
+	int	i;
+
+	i = 0;
+	while (str[i] >= '0' && str[i] <= '9')
+		i++;
+	if (str[i] == '\0')
+		return (1);
+	return (0);
+}
+
+
+char	*ft_str_tolower(char *str)
+{
+	int	i;
+
+	i = -1;
+	while (str[++i])
+		str[i] = ft_tolower(str[i]);
+	return (str);
 }


### PR DESCRIPTION
-nested minishell is now functional (and it increments SHLVL)
-fixed exit codes of commands with pipes, when signal ctrl c occurs while heredoc or blocking command occurs
-implemented a new echo function (to account for "echo -nnnn -n hello"
-updated dollar expansion to expand properly inside of heredoc and not to expand when '$' occurs as a delimiter of "<<"
-fixed exit codes for edge cases in exit, unset, and export
-accounted for uppercase use of echo, env, pwd, and clear (otherwise, it will use the system ones)